### PR TITLE
Fix the documentation inside the modules

### DIFF
--- a/library/hawkular_alerts_group_dampening.py
+++ b/library/hawkular_alerts_group_dampening.py
@@ -4,6 +4,7 @@
 DOCUMENTATION = '''
 ---
 module: hawkular_alerts_group_dampening
+description: The hawkular_alerts_group_dampening module supports creating, updating listing and deleting Group Trigger Dampenings in Hawkular Alerts
 short_description: Creating, updating listing and deleting Group Trigger Dampenings in Hawkular Alerting
 requirements: [ hawkular/hawkular-client-python ]
 author: Daniel Korn (@dkorn)
@@ -46,17 +47,17 @@ options:
     description:
       - the state of the group dampening
       - On present, it will create the group dampening
-      if it does not exist, or update it if needed
+        if it does not exist, or update it if needed
       - On absent, it will delete the group dampening,
-      if it exists
+        if it exists
     required: True
     choices: ['present', 'absent', 'list']
   dampenings:
     description:
       - A hash (dictionary) of group trigger dampening definitions to be
-      created, updated or deleted.
+        created, updated or deleted.
       - The key for each dampening is its trigger mode,
-      'FIRING' or 'AUTORESOLVE'
+        'FIRING' or 'AUTORESOLVE'
     required: False
     default: null
   verify_ssl:

--- a/library/hawkular_alerts_group_member.py
+++ b/library/hawkular_alerts_group_member.py
@@ -4,7 +4,8 @@
 DOCUMENTATION = '''
 ---
 module: hawkular_alerts_group_member
-short_description: Creating Group Trigger Members in Hawkular Alerting
+description: The hawkular_alerts_group_member module supports creating, updating, listing and deleting Group Trigger Members in Hawkular Alerts
+short_description: Creating, updating, listing and deleting Group Trigger Members in Hawkular Alerting
 requirements: [ hawkular/hawkular-client-python ]
 author: Daniel Korn (@dkorn)
 options:
@@ -59,9 +60,9 @@ options:
     description:
       - the state of the user
       - On present, it will create the group member trigger
-      if it does not exist
+        if it does not exist
       - On absent, it will delete the group member trigger
-      if it exists
+        if it exists
       - On list, it will find all group member triggers
     required: True
     choices: ['present', 'absent', 'list']

--- a/library/hawkular_alerts_group_trigger.py
+++ b/library/hawkular_alerts_group_trigger.py
@@ -4,7 +4,8 @@
 DOCUMENTATION = '''
 ---
 module: hawkular_alerts_group_trigger
-short_description: Creating, updating and deleting Group Triggers in Hawkular Alerting
+description: The hawkular_alerts_group_trigger module supports creating, updating, listing and deleting Group Triggers in Hawkular Alerts
+short_description: Creating, updating, listing and deleting Group Triggers in Hawkular Alerting
 requirements: [ hawkular/hawkular-client-python ]
 author: Daniel Korn (@dkorn)
 options:
@@ -40,7 +41,7 @@ options:
   group_id:
     description:
       - the group trigger id. This is the primary field on which one matches
-      an existing trigger
+        an existing trigger
     required: True
   severity:
     description:
@@ -72,9 +73,9 @@ options:
     description:
       - the state of the group trigger
       - On present, it will create the group trigger
-      if it does not exist, or update it if needed
+        if it does not exist, or update it if needed
       - On absent, it will delete the group trigger,
-      if it exists
+        if it exists
       - On list, it will return all triggers in the tenant
     required: True
     choices: ['present', 'absent', 'list']


### PR DESCRIPTION
Running `ansible-doc --module-path=library/ <module_name>.py` should output the module docs.
This change fixes few small issues preventing the docs display.